### PR TITLE
docs: Add OpenAPI specification

### DIFF
--- a/docs/api/openapi/README.md
+++ b/docs/api/openapi/README.md
@@ -1,0 +1,112 @@
+# API仕様書
+
+このディレクトリには、notion-markdownのOpenAPI仕様書が含まれています。
+
+## 概要
+
+- [openapi.yaml](./openapi.yaml) - OpenAPI 3.1.0形式のAPI仕様書
+- エンドポイントの詳細な説明とサンプルコード
+- エラーハンドリングとレスポンス形式の説明
+
+## 利用可能なエンドポイント
+
+1. `GET /api/pages/{pageId}`
+   - Notionページの取得
+   - Markdown形式でページの内容を取得
+
+2. `POST /api/pages/{pageId}`
+   - ページの更新
+   - 既存のページ内容を上書き
+
+3. `POST /api/pages/{pageId}/append`
+   - ページへの追記
+   - 既存のコンテンツを保持したまま追記
+
+4. `POST /api/pages`
+   - 新規ページの作成
+   - オプションで親ページを指定可能
+
+## 認証
+
+- NotionのAPIトークンを使用
+- リクエストヘッダーに`Authorization: Bearer your-token`形式で指定
+- トークンは環境変数`NOTION_API_KEY`での設定を推奨
+
+## レート制限
+
+- 1分あたり100リクエストまで
+- 制限超過時は429エラーを返却
+- Retry-Afterヘッダーで待機時間を通知
+
+## エラーハンドリング
+
+共通のエラーレスポンス形式：
+```json
+{
+  "error": "error_code",
+  "message": "エラーの詳細メッセージ"
+}
+```
+
+主なエラーコード：
+- `unauthorized` - 認証エラー（401）
+- `not_found` - リソースが見つからない（404）
+- `rate_limited` - レート制限超過（429）
+- `invalid_request` - リクエスト形式が不正（400）
+- `internal_error` - サーバーエラー（500）
+
+## 使用例
+
+### curlでの使用例
+
+```bash
+# ページの取得
+curl -X GET "http://localhost:3000/api/pages/1234-5678-9abc" \
+     -H "Authorization: Bearer your-token"
+
+# ページの更新
+curl -X POST "http://localhost:3000/api/pages/1234-5678-9abc" \
+     -H "Authorization: Bearer your-token" \
+     -H "Content-Type: application/json" \
+     -d '{"markdown": "# 更新されたページ\n\nこれは更新後のコンテンツです。"}'
+
+# ページへの追記
+curl -X POST "http://localhost:3000/api/pages/1234-5678-9abc/append" \
+     -H "Authorization: Bearer your-token" \
+     -H "Content-Type: application/json" \
+     -d '{"markdown": "## 新しいセクション\n\nこれは追記されたコンテンツです。"}'
+
+# 新規ページの作成
+curl -X POST "http://localhost:3000/api/pages" \
+     -H "Authorization: Bearer your-token" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "title": "新しいページ",
+       "markdown": "# 新しいページ\n\nこれは新しく作成されたページです。",
+       "parentId": "5678-1234-def0"
+     }'
+```
+
+## 注意事項
+
+1. APIトークンの管理
+   - トークンは安全に管理
+   - 環境変数での設定を推奨
+   - 定期的なトークンのローテーションを推奨
+
+2. エラーハンドリング
+   - すべてのエラーに適切に対応
+   - リトライロジックの実装を推奨
+   - レート制限の考慮
+
+3. コンテンツの制限
+   - Markdownの最大サイズは100KB
+   - 画像や添付ファイルは非対応
+   - 一部のMarkdown記法に制限あり
+
+## 関連ドキュメント
+
+- [セットアップガイド](../../guides/setup/README.md)
+- [認証ガイド](../../guides/authentication.md)
+- [エラーハンドリング](../../guides/error-handling.md)
+- [ベストプラクティス](../../guides/best-practices/README.md)

--- a/docs/api/openapi/openapi.yaml
+++ b/docs/api/openapi/openapi.yaml
@@ -1,0 +1,290 @@
+openapi: 3.1.0
+info:
+  title: Notion Markdown API
+  description: |
+    NotionのページをMarkdown形式で取得・更新するためのAPI。
+    このAPIを使用することで、NotionのページをMarkdownとして扱い、
+    双方向の変換と同期が可能になります。
+  version: 1.0.0
+  contact:
+    name: notion-markdown Support
+    url: https://github.com/hirokidaichi/notion-markdown/issues
+
+servers:
+  - url: http://localhost:3000
+    description: 開発サーバー
+  - url: https://api.notion-markdown.example.com
+    description: 本番サーバー（例）
+
+security:
+  - ApiKeyAuth: []
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: |
+        NotionのAPIトークンをBearer形式で指定します。
+        例: `Bearer your-notion-api-token`
+
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: エラーコード
+          example: unauthorized
+        message:
+          type: string
+          description: エラーメッセージ
+          example: Invalid API key
+      required:
+        - error
+        - message
+
+    PageMetadata:
+      type: object
+      properties:
+        title:
+          type: string
+          description: ページのタイトル
+          example: サンプルページ
+        created_at:
+          type: string
+          format: date-time
+          description: 作成日時
+          example: "2024-02-12T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: 更新日時
+          example: "2024-02-12T10:30:00Z"
+      required:
+        - title
+        - created_at
+        - updated_at
+
+    MarkdownContent:
+      type: object
+      properties:
+        markdown:
+          type: string
+          description: Markdown形式のコンテンツ
+          example: |
+            # サンプルページ
+            
+            これはNotionからMarkdownとして取得したコンテンツです。
+            
+            ## セクション1
+            
+            - リスト項目1
+            - リスト項目2
+        metadata:
+          $ref: "#/components/schemas/PageMetadata"
+      required:
+        - markdown
+        - metadata
+
+paths:
+  /api/pages/{pageId}:
+    parameters:
+      - name: pageId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: NotionのページID
+        example: 1234-5678-9abc
+    
+    get:
+      summary: Notionページの取得
+      description: |
+        指定されたIDのNotionページをMarkdown形式で取得します。
+        ページの内容とメタデータが返されます。
+      operationId: getPage
+      tags:
+        - pages
+      responses:
+        "200":
+          description: 正常にページを取得
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarkdownContent"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: ページが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "429":
+          description: レート制限超過
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    
+    post:
+      summary: ページの更新
+      description: |
+        指定されたIDのNotionページをMarkdown形式で更新します。
+        既存のコンテンツは上書きされます。
+      operationId: updatePage
+      tags:
+        - pages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                markdown:
+                  type: string
+                  description: 更新するMarkdownコンテンツ
+                  example: |
+                    # 更新されたページ
+                    
+                    これは更新後のコンテンツです。
+              required:
+                - markdown
+      responses:
+        "200":
+          description: 正常に更新
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarkdownContent"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: ページが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/pages/{pageId}/append:
+    parameters:
+      - name: pageId
+        in: path
+        required: true
+        schema:
+          type: string
+        description: NotionのページID
+        example: 1234-5678-9abc
+    
+    post:
+      summary: ページへの追記
+      description: |
+        指定されたIDのNotionページに新しいコンテンツを追記します。
+        既存のコンテンツは保持されます。
+      operationId: appendToPage
+      tags:
+        - pages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                markdown:
+                  type: string
+                  description: 追記するMarkdownコンテンツ
+                  example: |
+                    ## 新しいセクション
+                    
+                    これは追記されたコンテンツです。
+              required:
+                - markdown
+      responses:
+        "200":
+          description: 正常に追記
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarkdownContent"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: ページが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/pages:
+    post:
+      summary: 新規ページの作成
+      description: |
+        新しいNotionページをMarkdown形式で作成します。
+        親ページIDを指定することで、特定のページ配下に作成することができます。
+      operationId: createPage
+      tags:
+        - pages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: ページのタイトル
+                  example: 新しいページ
+                markdown:
+                  type: string
+                  description: ページのMarkdownコンテンツ
+                  example: |
+                    # 新しいページ
+                    
+                    これは新しく作成されたページです。
+                parentId:
+                  type: string
+                  description: 親ページのID（オプション）
+                  example: 5678-1234-def0
+              required:
+                - title
+                - markdown
+      responses:
+        "201":
+          description: 正常に作成
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarkdownContent"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 親ページが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+tags:
+  - name: pages
+    description: ページの操作に関するエンドポイント


### PR DESCRIPTION
## 概要
NotionページをMarkdown形式で操作するためのAPI仕様書を作成しました。

## 変更内容
- OpenAPI 3.1.0形式でのAPI仕様書の作成
- 各エンドポイントの詳細な説明
- リクエスト/レスポンス例の追加
- エラーハンドリングの説明
- レート制限に関する情報の追加

## 主な機能
1. ページの取得（GET /api/pages/{pageId}）
2. ページの更新（POST /api/pages/{pageId}）
3. ページへの追記（POST /api/pages/{pageId}/append）
4. 新規ページの作成（POST /api/pages）

## レビューのポイント
- API仕様は明確で理解しやすいか
- エラーハンドリングは適切か
- 認証方法は明確か
- 使用例は十分か

## 関連issue
Closes #6

## チェックリスト
- [x] OpenAPI仕様書の作成
- [x] エンドポイントの詳細な説明
- [x] リクエスト/レスポンス例の追加
- [x] エラーケースの説明
- [x] レート制限の説明
- [x] 認証方法の説明
- [x] 使用例の追加

## 今後の作業
1. クライアントライブラリの生成
2. APIテストの作成
3. APIドキュメントの自動生成